### PR TITLE
Fix wrong php extension directory

### DIFF
--- a/php/tasks/php5-extensions.yml
+++ b/php/tasks/php5-extensions.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Register php extensions directory
-  shell: php -i 2>/dev/null | grep extension_dir | awk -F" => " '{ print $2; }'
+  shell: php -i 2>/dev/null | grep "^extension_dir" | awk -F" => " '{ print $2; }'
   register: php_extension_dir
 
 - name: Add ppa mongodb-drivers for ubuntu < 14.04


### PR DESCRIPTION
It was conflicting with some php extensions which contains "extension_dir" as configurable parameter (such as "sqlite3.extension_dir").
=> xdebug extension wasn't successfully configured because of that.
