### PR TITLE
Add python role

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ Take a look at each role's `defaults/main.yml` file to see all overridable varia
 
 | Variable    | Roles       | Description |
 |:-----------:|:-----------:|-------------|
+| pip_packages | python | **ARRAY** <br>List of python packages to install using `pip install` command (for each python_versions). <br>Default value is `[]`. |
 | php_disable_xdebug_cli | php | If set to `false`, xdebug php extension will be enabled in PHP CLI (which considerably reduces "composer" speed). <br>Default value is `true`. |
 | php_memory_limit | php | Defines [`memory_limit` setting in `php.ini`](http://php.net/manual/en/ini.core.php#ini.memory-limit). <br>Default value is `'2G'`. |
 | php_versions | php | **ARRAY** <br>Supported versions are `'5.5'`, `'5.6'`, `'7.0'`. The `php` shell command, the `sites[x].fastcgi_pass` default value for nginx templates and the `php apache module` will all use the first php version found in this array. To switch apache's php versions, you'll have to dismiss current php module, and enable the wanted one (e.g. to stop using php5.6 and start using php7.0: `sudo a2dismod php5.6 && sudo a2enmod php7.0 && sudo service apache2 restart`). <br>Default value is `['5.6']`. |
 | php_xdebug_remote_port | php | Port on which you can listen to start a remote debugging connection. <br>Default value is `'9000'`. |
+| python_versions | python | **ARRAY** <br>Supported versions are `'2.7'`, `'3.5'`. The `python` and `pip` shell commands will all use the first python version found in this array (if `python_is_first_python_versions`). <br>Default value is `['3.5']`. |
+| python_is_first_python_versions | python | If set to `false`, the `python` and `pip` shell commands will be left as is (you may want this behavior if you have unexpected issues). <br>Default value is `true`. |
 | sites | apache/nginx | **ARRAY** <br>[See "Nginx/Apache section"](#nginxapache-server-configuration). <br>Default value is `[]`. |
 | zsh_additional_commands | oh-my-zsh | **MULTI-LINES** <br>Allow to set additional commands which will be executed each time you open a ZSH terminal. <br>Default value is `export IS_VM=true`. |
 | zsh_editor | oh-my-zsh | Default terminal editor. <br>Default value is `'vim'`. |

--- a/python/defaults/main.yml
+++ b/python/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+
+python_versions: ['3.5']
+python_is_first_python_versions: true
+
+pip_packages: []

--- a/python/tasks/main.yml
+++ b/python/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+
+- name: Add python ppa (fkrull/deadsnakes)
+  apt_repository: repo="ppa:fkrull/deadsnakes" state=present
+
+- name: Include python2.7.yml
+  include: python2.7.yml
+  when: ('2.7' in python_versions)
+
+- name: Include python3.5.yml
+  include: python3.5.yml
+  when: ('3.5' in python_versions)
+
+- name: Bind python command to first version from python_versions (if python_is_first_python_versions)
+  file: src="/usr/bin/python{{ python_versions|first }}" dest=/usr/bin/python state=link force=yes
+  when: python_is_first_python_versions
+
+- name: Bind pip command to first version from python_versions (if python_is_first_python_versions)
+  file: src="/usr/local/bin/pip{{ python_versions|first }}" dest=/usr/local/bin/pip state=link force=yes
+  when: python_is_first_python_versions

--- a/python/tasks/python2.7.yml
+++ b/python/tasks/python2.7.yml
@@ -1,0 +1,17 @@
+---
+
+- name: Add python2.7 ppa (fkrull/deadsnakes-python2.7)
+  apt_repository: repo="ppa:fkrull/deadsnakes-python2.7" state=present
+
+- name: Install python2.7
+  apt: name=python2.7-dev state=latest
+
+- name: Install pip2.7
+  apt: name=python-pip state=latest
+
+- name: Update pip2.7
+  shell: python2.7 -m pip install pip --upgrade
+
+- name: Install pip2.7 packages
+  pip: name={{ item }} state=present executable='pip2.7'
+  with_items: pip_packages

--- a/python/tasks/python3.5.yml
+++ b/python/tasks/python3.5.yml
@@ -1,0 +1,14 @@
+---
+
+- name: Install python3.5
+  apt: name=python3.5-complete state=latest
+
+- name: Install pip3.5
+  shell: python3.5 -m ensurepip
+
+- name: Update pip3.5
+  pip: name=pip state=latest executable='pip3.5'
+
+- name: Install pip3.5 packages
+  pip: name={{ item }} state=present executable='pip3.5'
+  with_items: pip_packages


### PR DESCRIPTION
## Features
- install multiple `python` versions (2.7 or/and 3.5)
- install multiple `pip` (one for each python version)
- install packages using `pip install [PACKAGES]`
- allow to symlink python/pip shell command to a specific version (i.e. the first version specified in `python_versions` variable)
