### PR TITLE
Doc and fix php extensions + fix default language-pack installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ Take a look at each role's `defaults/main.yml` file to see all overridable varia
 | Variable    | Roles       | Description |
 |:-----------:|:-----------:|-------------|
 | pip_packages | python | **ARRAY** <br>List of python packages to install using `pip install` command (for each python_versions). <br>Default value is `[]`. |
+| php55_extensions | php | **ARRAY** <br>List of apt-get packages which will be installed if `php_versions` contains `5.5`. <br>See default value [here](php/defaults/main.yml). |
+| php56_extensions | php | **ARRAY** <br>List of apt-get packages which will be installed if `php_versions` contains `5.6`. <br>See default value [here](php/defaults/main.yml). |
+| php70_extensions | php | **ARRAY** <br>List of apt-get packages which will be installed if `php_versions` contains `7.0`. <br>See default value [here](php/defaults/main.yml). |
 | php_disable_xdebug_cli | php | If set to `false`, xdebug php extension will be enabled in PHP CLI (which considerably reduces "composer" speed). <br>Default value is `true`. |
 | php_memory_limit | php | Defines [`memory_limit` setting in `php.ini`](http://php.net/manual/en/ini.core.php#ini.memory-limit). <br>Default value is `'2G'`. |
 | php_versions | php | **ARRAY** <br>Supported versions are `'5.5'`, `'5.6'`, `'7.0'`. The `php` shell command, the `sites[x].fastcgi_pass` default value for nginx templates and the `php apache module` will all use the first php version found in this array. To switch apache's php versions, you'll have to dismiss current php module, and enable the wanted one (e.g. to stop using php5.6 and start using php7.0: `sudo a2dismod php5.6 && sudo a2enmod php7.0 && sudo service apache2 restart`). <br>Default value is `['5.6']`. |

--- a/common-packages/defaults/main.yml
+++ b/common-packages/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 common_packages:
-  - language-pack-fr
+  - language-pack-en
   - build-essential
   - software-properties-common
   - python-software-properties

--- a/php/defaults/main.yml
+++ b/php/defaults/main.yml
@@ -5,29 +5,86 @@ php_memory_limit: '2G'
 php_disable_xdebug_cli: true
 php_xdebug_remote_port: '9000'
 
-php_extensions:
-  - php-common
-  - php-curl
-  - php-gd
+php55_extensions:
+  - php5.5-bcmath
+  - php5.5-common
+  - php5.5-curl
+  - php5.5-gd
+  - php5.5-imap
+  - php5.5-intl
+  - php5.5-json
+  - php5.5-ldap
+  - php5.5-mbstring
+  - php5.5-mcrypt
+  - php5.5-mysql
+  - php5.5-pgsql
+  - php5.5-readline
+  - php5.5-sqlite3
+  - php5.5-xml
+  - php5.5-zip
+  - php-amqp
+  - php-apcu
   - php-imagick
-  - php-imap
-  - php-intl
-  - php-json
-  - php-ldap
-  - php-mbstring
-  - php-mcrypt
   - php-memcache
   - php-mongodb
-  - php-mysql
-  - php-pgsql
   - php-phpdbg
-  - php-readline
   - php-redis
-  - php-sqlite3
   - php-stomp
   - php-xdebug
-  - php-xml
-  - php-zip
+
+php56_extensions:
+  - php5.6-bcmath
+  - php5.6-common
+  - php5.6-curl
+  - php5.6-gd
+  - php5.6-imap
+  - php5.6-intl
+  - php5.6-json
+  - php5.6-ldap
+  - php5.6-mbstring
+  - php5.6-mcrypt
+  - php5.6-mysql
+  - php5.6-pgsql
+  - php5.6-readline
+  - php5.6-sqlite3
+  - php5.6-xml
+  - php5.6-zip
+  - php-amqp
+  - php-apcu
+  - php-imagick
+  - php-memcache
+  - php-mongodb
+  - php-phpdbg
+  - php-redis
+  - php-stomp
+  - php-xdebug
+
+php70_extensions:
+  - php7.0-bcmath
+  - php7.0-common
+  - php7.0-curl
+  - php7.0-gd
+  - php7.0-imap
+  - php7.0-intl
+  - php7.0-json
+  - php7.0-ldap
+  - php7.0-mbstring
+  - php7.0-mcrypt
+  - php7.0-mysql
+  - php7.0-pgsql
+  - php7.0-readline
+  - php7.0-sqlite3
+  - php7.0-xml
+  - php7.0-zip
+  - php-amqp
+  - php-apcu
+  - php-imagick
+  - php-memcache
+  - php-mongodb
+  - php-phpdbg
+  - php-redis
+  - php-stomp
+  - php-xdebug
 
 fpm_pools:
     - { name: 'www' }

--- a/php/tasks/php5.5-extensions.yml
+++ b/php/tasks/php5.5-extensions.yml
@@ -2,15 +2,15 @@
 
 - name: Install php5.5 extensions
   apt: name={{ item }} state=present
-  with_items: php_extensions
+  with_items: php55_extensions
 
 - name: Configure php5.5 xdebug
   template: src=xdebug.ini.j2 dest="/etc/php/5.5/mods-available/xdebug.ini" mode=0644
-  when: ('php-xdebug' in php_extensions)
+  when: ('php-xdebug' in php55_extensions)
 
 - name: Disable xdebug for php5.5 phpdbg
   file: dest="/etc/php/5.5/phpdbg/conf.d/20-xdebug.ini" state=absent
-  when: ('php-phpdbg' in php_extensions)
+  when: ('php-phpdbg' in php55_extensions)
 
 - name: Disable xdebug for php5.5 cli
   file: dest="/etc/php/5.5/cli/conf.d/20-xdebug.ini" state=absent

--- a/php/tasks/php5.6-extensions.yml
+++ b/php/tasks/php5.6-extensions.yml
@@ -2,15 +2,15 @@
 
 - name: Install php5.6 extensions
   apt: name={{ item }} state=present
-  with_items: php_extensions
+  with_items: php56_extensions
 
 - name: Configure php5.6 xdebug
   template: src=xdebug.ini.j2 dest="/etc/php/5.6/mods-available/xdebug.ini" mode=0644
-  when: ('php-xdebug' in php_extensions)
+  when: ('php-xdebug' in php56_extensions)
 
 - name: Disable xdebug for php5.6 phpdbg
   file: dest="/etc/php/5.6/phpdbg/conf.d/20-xdebug.ini" state=absent
-  when: ('php-phpdbg' in php_extensions)
+  when: ('php-phpdbg' in php56_extensions)
 
 - name: Disable xdebug for php5.6 cli
   file: dest="/etc/php/5.6/cli/conf.d/20-xdebug.ini" state=absent

--- a/php/tasks/php7.0-extensions.yml
+++ b/php/tasks/php7.0-extensions.yml
@@ -2,15 +2,15 @@
 
 - name: Install php7.0 extensions
   apt: name={{ item }} state=present
-  with_items: php_extensions
+  with_items: php70_extensions
 
 - name: Configure php7.0 xdebug
   template: src=xdebug.ini.j2 dest="/etc/php/7.0/mods-available/xdebug.ini" mode=0644
-  when: ('php-xdebug' in php_extensions)
+  when: ('php-xdebug' in php70_extensions)
 
 - name: Disable xdebug for php7.0 phpdbg
   file: dest="/etc/php/7.0/phpdbg/conf.d/20-xdebug.ini" state=absent
-  when: ('php-phpdbg' in php_extensions)
+  when: ('php-phpdbg' in php70_extensions)
 
 - name: Disable xdebug for php7.0 cli
   file: dest="/etc/php/7.0/cli/conf.d/20-xdebug.ini" state=absent


### PR DESCRIPTION
## Why

Because php-\* extensions weren't all installed as expected for all php versions. It's safer to rely on php5.5-_, php5.6-_ and php7.0-*

Note: This won't be a major release, even if there is a breaking change, because the breaking change wasn't even documented (i.e. php_versions -> php55_extensions, etc.)
