### PR TITLE
fix locales issues + allow locale configuration + extra_packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Take a look at each role's `defaults/main.yml` file to see all overridable varia
 
 | Variable    | Roles       | Description |
 |:-----------:|:-----------:|-------------|
+| common_packages | common-packages | **ARRAY** <br>List of common packages to install using `apt-get install` command. <br>See default value [here](common-packages/defaults/main.yml). |
+| extra_packages | common-packages | **ARRAY** <br>List of extra packages to install using `apt-get install` command. <br>Default value is `[]`. |
+| language | common-packages | Value for "locales" related environment variables (i.e. `LANG`, `LANGUAGE`, `LC_ALL`). <br>Default value is `en_US.UTF-8`. |
 | pip_packages | python | **ARRAY** <br>List of python packages to install using `pip install` command (for each python_versions). <br>Default value is `[]`. |
 | php55_extensions | php | **ARRAY** <br>List of apt-get packages which will be installed if `php_versions` contains `5.5`. <br>See default value [here](php/defaults/main.yml). |
 | php56_extensions | php | **ARRAY** <br>List of apt-get packages which will be installed if `php_versions` contains `5.6`. <br>See default value [here](php/defaults/main.yml). |
@@ -31,6 +34,7 @@ Take a look at each role's `defaults/main.yml` file to see all overridable varia
 | python_versions | python | **ARRAY** <br>Supported versions are `'2.7'`, `'3.5'`. <br>Default value is `['3.5']`. |
 | python_is_first_python_versions | python | If set to `true`, the `python` and `pip` shell commands will all use the first python version found in `python_versions` array (it may lead to unexpected issues because Ansible itself use `python`). <br>Default value is `false`. |
 | sites | apache/nginx | **ARRAY** <br>[See "Nginx/Apache section"](#nginxapache-server-configuration). <br>Default value is `[]`. |
+| timezone | common-packages | Value for timezone system configuration. <br>Default value is `UTC`. |
 | zsh_additional_commands | oh-my-zsh | **MULTI-LINES** <br>Allow to set additional commands which will be executed each time you open a ZSH terminal. <br>Default value is `export IS_VM=true`. |
 | zsh_editor | oh-my-zsh | Default terminal editor. <br>Default value is `'vim'`. |
 | zsh_theme | oh-my-zsh | Supported themes for `oh-my-zsh` are located in `~/.oh-my-zsh/themes/` inside the VM. <br>Default value is `'robbyrussell'`. |

--- a/common-packages/defaults/main.yml
+++ b/common-packages/defaults/main.yml
@@ -1,7 +1,6 @@
 ---
 
 common_packages:
-  - language-pack-en
   - build-essential
   - software-properties-common
   - python-software-properties
@@ -16,4 +15,8 @@ common_packages:
   - tar
   - ntp
 
+extra_packages: []
+
+language: 'en_US.UTF-8'
 timezone: 'UTC'
+base_path: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games'

--- a/common-packages/tasks/main.yml
+++ b/common-packages/tasks/main.yml
@@ -14,3 +14,15 @@
 - name: Install common packages
   apt: name={{ item }} state=present
   with_items: common_packages
+
+- name: Install extra packages
+  apt: name={{ item }} state=present
+  with_items: extra_packages
+
+- name: Set environment config file
+  template:
+    src=environment.j2
+    dest=/etc/environment
+
+- name: Reconfigure locales
+  command: dpkg-reconfigure locales

--- a/common-packages/templates/environment.j2
+++ b/common-packages/templates/environment.j2
@@ -1,0 +1,4 @@
+PATH="{{ base_path }}"
+LANG="{{ language }}"
+LANGUAGE="{{ language }}"
+LC_ALL="{{ language }}"


### PR DESCRIPTION
## Why

We had some locales issues (perl ... LANG = (unset) ...). This is fixed now.

Now we can even choose the system language, by combinating `extra_packages` with `language` variables.

Let's say I want to have a french system (assuming we include the `common-packages` role): 

```
extra_packages: [ 'language-pack-fr' ]
language: 'fr_FR.UTF-8'
```

It's that easy :)
