### PR TITLE
add composer_packages + fixes + upgrade default versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Compilation of Ansible roles for Ubuntu 14.04 (for Ubuntu 12.04, use the old [v0
 
 The easiest way to get started is to try our [Vagrant implementation](https://github.com/LinkValue/majora-ansible-vagrant).
 
+*Pro tips:* If you don't want any troubles, you should always start by including the `common-packages` role in your machine.
 
 
 ## Variables reference (in alphabetical order)
@@ -21,8 +22,15 @@ Take a look at each role's `defaults/main.yml` file to see all overridable varia
 | Variable    | Roles       | Description |
 |:-----------:|:-----------:|-------------|
 | common_packages | common-packages | **ARRAY** <br>List of common packages to install using `apt-get install` command. <br>See default value [here](common-packages/defaults/main.yml). |
+| composer_github_token | composer | [GitHub personal access token](https://github.com/settings/tokens) to pass through the composer download limit. <br>Default value is `''`. |
+| composer_packages | composer | **ARRAY** <br>List of composer packages to install globally using `composer global install` command. <br>Default value is `['symfony/var-dumper']` (which allows you to use `dump()` function everywhere). |
 | extra_packages | common-packages | **ARRAY** <br>List of extra packages to install using `apt-get install` command. <br>Default value is `[]`. |
 | language | common-packages | Value for "locales" related environment variables (i.e. `LANG`, `LANGUAGE`, `LC_ALL`). <br>Default value is `en_US.UTF-8`. |
+| main_group | composer/oh-my-zsh/ssh-forward | Main group (main user's group). <br>Default value is `vagrant`. |
+| main_user | composer/oh-my-zsh/ssh-forward | Main user (the one you'll use in the provisioned machine). <br>Default value is `vagrant`. |
+| main_user_home_dir | composer/oh-my-zsh/ssh-forward | Main user's home directory. <br>Default value is `/home/vagrant`. |
+| node_version | nodejs | NodeJS version to install. This value will be append to `https://deb.nodesource.com/setup_`. <br>Default value is `6.x`. |
+| npm_packages | nodejs | **ARRAY** <br>List of npm packages to install globally using `npm install -g` command. <br>See default value [here](nodejs/defaults/main.yml). |
 | pip_packages | python | **ARRAY** <br>List of python packages to install using `pip install` command (for each python_versions). <br>Default value is `[]`. |
 | php55_extensions | php | **ARRAY** <br>List of apt-get packages which will be installed if `php_versions` contains `5.5`. <br>See default value [here](php/defaults/main.yml). |
 | php56_extensions | php | **ARRAY** <br>List of apt-get packages which will be installed if `php_versions` contains `5.6`. <br>See default value [here](php/defaults/main.yml). |
@@ -30,12 +38,13 @@ Take a look at each role's `defaults/main.yml` file to see all overridable varia
 | php71_extensions | php | **ARRAY** <br>List of apt-get packages which will be installed if `php_versions` contains `7.1`. <br>See default value [here](php/defaults/main.yml). |
 | php_disable_xdebug_cli | php | If set to `false`, xdebug php extension will be enabled in PHP CLI (which considerably reduces "composer" speed). <br>Default value is `true`. |
 | php_memory_limit | php | Defines [`memory_limit` setting in `php.ini`](http://php.net/manual/en/ini.core.php#ini.memory-limit). <br>Default value is `'2G'`. |
-| php_versions | php | **ARRAY** <br>Supported versions are `'5.5'`, `'5.6'`, `'7.0'`, `'7.1'`. The `php` shell command, the `sites[x].fastcgi_pass` default value for nginx templates and the `php apache module` will all use the first php version found in this array. To switch apache's php versions, you'll have to dismiss current php module, and enable the wanted one (e.g. to stop using php5.6 and start using php7.0: `sudo a2dismod php5.6 && sudo a2enmod php7.0 && sudo service apache2 restart`). <br>Default value is `['5.6']`. |
+| php_versions | php | **ARRAY** <br>Supported versions are `'5.5'`, `'5.6'`, `'7.0'`, `'7.1'`. The `php` shell command, the `sites[x].fastcgi_pass` default value for nginx templates and the `php apache module` will all use the first php version found in this array. To switch apache's php versions, you'll have to dismiss current php module, and enable the wanted one (e.g. to stop using php5.6 and start using php7.0: `sudo a2dismod php5.6 && sudo a2enmod php7.0 && sudo service apache2 restart`). <br>Default value is `['7.0']`. |
 | php_xdebug_remote_port | php | Port on which you can listen to start a remote debugging connection. <br>Default value is `'9000'`. |
 | python_versions | python | **ARRAY** <br>Supported versions are `'2.7'`, `'3.5'`. <br>Default value is `['3.5']`. |
 | python_is_first_python_versions | python | If set to `true`, the `python` and `pip` shell commands will all use the first python version found in `python_versions` array (it may lead to unexpected issues because Ansible itself use `python`). <br>Default value is `false`. |
 | sites | apache/nginx | **ARRAY** <br>[See "Nginx/Apache section"](#nginxapache-server-configuration). <br>Default value is `[]`. |
 | timezone | common-packages | Value for timezone system configuration. <br>Default value is `UTC`. |
+| workspace | oh-my-zsh | Full path directory where you'll land on session start. <br>Default value is `/var/www`. |
 | zsh_additional_commands | oh-my-zsh | **MULTI-LINES** <br>Allow to set additional commands which will be executed each time you open a ZSH terminal. <br>Default value is `export IS_VM=true`. |
 | zsh_editor | oh-my-zsh | Default terminal editor. <br>Default value is `'vim'`. |
 | zsh_theme | oh-my-zsh | Supported themes for `oh-my-zsh` are located in `~/.oh-my-zsh/themes/` inside the VM. <br>Default value is `'robbyrussell'`. |

--- a/composer/defaults/main.yml
+++ b/composer/defaults/main.yml
@@ -5,3 +5,6 @@ main_group: 'vagrant'
 main_user_home_dir: '/home/vagrant'
 
 composer_github_token: ''
+
+composer_packages:
+  - 'symfony/var-dumper'

--- a/composer/tasks/global-autoloader.yml
+++ b/composer/tasks/global-autoloader.yml
@@ -1,0 +1,111 @@
+---
+
+# PHP5.5
+- name: Setup autoloader for php5.5 cli
+  lineinfile:
+    dest: '/etc/php/5.5/cli/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  when: ('5.5' in php_versions)
+
+- name: Setup autoloader for php5.5 fpm
+  lineinfile:
+    dest: '/etc/php/5.5/fpm/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  notify:
+    - Restart php5.5-fpm
+  when: ('5.5' in php_versions) and (fpm is defined and fpm)
+
+- name: Setup autoloader for php5.5 apache
+  lineinfile:
+    dest: '/etc/php/5.5/apache/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  notify:
+    - Restart apache2
+  when: ('5.5' in php_versions) and (apache_mod_php is defined and apache_mod_php)
+
+
+
+# PHP5.6
+- name: Setup autoloader for php5.6 cli
+  lineinfile:
+    dest: '/etc/php/5.6/cli/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  when: ('5.6' in php_versions)
+
+- name: Setup autoloader for php5.6 fpm
+  lineinfile:
+    dest: '/etc/php/5.6/fpm/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  notify:
+    - Restart php5.6-fpm
+  when: ('5.6' in php_versions) and (fpm is defined and fpm)
+
+- name: Setup autoloader for php5.6 apache
+  lineinfile:
+    dest: '/etc/php/5.6/apache/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  notify:
+    - Restart apache2
+  when: ('5.6' in php_versions) and (apache_mod_php is defined and apache_mod_php)
+
+
+
+# PHP7.0
+- name: Setup autoloader for php7.0 cli
+  lineinfile:
+    dest: '/etc/php/7.0/cli/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  when: ('7.0' in php_versions)
+
+- name: Setup autoloader for php7.0 fpm
+  lineinfile:
+    dest: '/etc/php/7.0/fpm/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  notify:
+    - Restart php7.0-fpm
+  when: ('7.0' in php_versions) and (fpm is defined and fpm)
+
+- name: Setup autoloader for php7.0 apache
+  lineinfile:
+    dest: '/etc/php/7.0/apache/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  notify:
+    - Restart apache2
+  when: ('7.0' in php_versions) and (apache_mod_php is defined and apache_mod_php)
+
+
+
+# PHP7.1
+- name: Setup autoloader for php7.1 cli
+  lineinfile:
+    dest: '/etc/php/7.1/cli/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  when: ('7.1' in php_versions)
+
+- name: Setup autoloader for php7.1 fpm
+  lineinfile:
+    dest: '/etc/php/7.1/fpm/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  notify:
+    - Restart php7.1-fpm
+  when: ('7.1' in php_versions) and (fpm is defined and fpm)
+
+- name: Setup autoloader for php7.1 apache
+  lineinfile:
+    dest: '/etc/php/7.1/apache/php.ini'
+    insertafter: '^auto_prepend_file'
+    line: 'auto_prepend_file = {{ composer_autoloader }}'
+  notify:
+    - Restart apache2
+  when: ('7.1' in php_versions) and (apache_mod_php is defined and apache_mod_php)

--- a/composer/tasks/main.yml
+++ b/composer/tasks/main.yml
@@ -5,8 +5,30 @@
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
     composer self-update
 
-- name: Make sure main user has .composer directory
-  file: dest='{{ main_user_home_dir }}/.composer' state=directory owner={{ main_user }} group={{ main_group }}
+- name: Install composer global packages
+  command: 'composer global require {{ item }}'
+  with_items: composer_packages
+
+- name: Get fact of composer_root_user_home
+  stat: path='/root/.composer'
+  register: composer_root_user_home
+
+- name: Copy composer directory from root user to main user
+  command: '\cp -rf /root/.composer {{ main_user_home_dir }}/'
+  when: composer_root_user_home.stat.exists
+
+- name: Setup permissions for main user's composer home
+  file: dest='{{ main_user_home_dir }}/.composer' state=directory owner={{ main_user }} group={{ main_group }} recurse=yes
+
+- name: Get fact of composer_main_user_autoloader
+  stat: path='{{ main_user_home_dir }}/.composer/vendor/autoload.php'
+  register: composer_main_user_autoloader
+
+- name: Setup composer global packages autoloading
+  include: global-autoloader.yml
+  vars:
+    composer_autoloader: '{{ main_user_home_dir }}/.composer/vendor/autoload.php'
+  when: composer_main_user_autoloader.stat.exists
 
 - name: Set github personal token for main user
   template: src=auth.json.j2 dest='{{ main_user_home_dir }}/.composer/auth.json' owner={{ main_user }} group={{ main_group }}

--- a/logstash/defaults/main.yml
+++ b/logstash/defaults/main.yml
@@ -2,7 +2,7 @@
 
 logstash_version: '2.1'
 
-logstash_config: >
+logstash_config: |
   input {
     # inputs
   }

--- a/nodejs/defaults/main.yml
+++ b/nodejs/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-node_version: '5.x'
+node_version: '6.x'
 
 npm_packages:
   - pm2

--- a/oh-my-zsh/defaults/main.yml
+++ b/oh-my-zsh/defaults/main.yml
@@ -1,11 +1,12 @@
 ---
 
 main_user: 'vagrant'
+main_group: 'vagrant'
 main_user_home_dir: '/home/vagrant'
 
 workspace: '/var/www'
 
 zsh_theme: 'robbyrussell'
 zsh_editor: 'vim'
-zsh_additional_commands: >
+zsh_additional_commands: |
   export IS_VM=true

--- a/oh-my-zsh/tasks/main.yml
+++ b/oh-my-zsh/tasks/main.yml
@@ -9,7 +9,7 @@
   template: src=zshrc.j2 dest=~/.zshrc
 
 - name: Configure oh-my-zsh for main user
-  template: src=zshrc.j2 dest='{{ main_user_home_dir }}/.zshrc'
+  template: src=zshrc.j2 dest='{{ main_user_home_dir }}/.zshrc' owner={{ main_user }} group={{ main_group }}
 
 - name: Set zsh as default shell for root user
   user: name=root shell=/bin/zsh

--- a/php/defaults/main.yml
+++ b/php/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 
-php_versions: ['5.6']
+php_versions: ['7.0']
 php_memory_limit: '2G'
 php_disable_xdebug_cli: true
 php_xdebug_remote_port: '9000'

--- a/php/tasks/php.yml
+++ b/php/tasks/php.yml
@@ -15,6 +15,10 @@
   include: php7.0.yml
   when: ('7.0' in php_versions)
 
+- name: Include php7.1.yml
+  include: php7.1.yml
+  when: ('7.1' in php_versions)
+
 - name: Include php5.5-extensions.yml
   include: php5.5-extensions.yml
   when: ('5.5' in php_versions)

--- a/ssh-forward/tasks/main.yml
+++ b/ssh-forward/tasks/main.yml
@@ -6,6 +6,6 @@
     - id_rsa
 
 - name: Forward ssh folder for main user
-  copy: src='{{ ssh_folder }}/{{ item }}' dest='{{ main_user_home_dir }}/.ssh/{{ item }}' owner={{ main_user }} group={{ main_user }} mode=600
+  copy: src='{{ ssh_folder }}/{{ item }}' dest='{{ main_user_home_dir }}/.ssh/{{ item }}' owner={{ main_user }} group={{ main_group }} mode=600
   with_items:
     - id_rsa


### PR DESCRIPTION
- Add composer_packages variable to install some composer global packages (those packages will be automatically autoloaded in `php.ini` using `auto_prepend_file`).
  By default, the `symfony/var-dumper` package is installed, in order to be able to use `dump()` function everywhere (except `php -r "dump(...);"`) in the provisioned machine.
- Fix php7.1 "main" installation
- PHP default version is now `7.0`
- NodeJS default version is now `6.x`
- Documentation for some other variables
